### PR TITLE
direct shiboken to use python2.7

### DIFF
--- a/cmake/shiboken_helper.cmake
+++ b/cmake/shiboken_helper.cmake
@@ -3,6 +3,7 @@ if(__PYTHON_QT_BINDING_SHIBOKEN_HELPER_INCLUDED)
 endif()
 set(__PYTHON_QT_BINDING_SHIBOKEN_HELPER_INCLUDED TRUE)
 
+set(PYTHON_SUFFIX -python2.7)
 find_package(Shiboken)
 find_package(PySide)
 find_package(PythonLibs)


### PR DESCRIPTION
it appears that (at least on ubuntu 13.04 and 13.10) shiboken does not have valid python3 cmake files installed on the system, and only a file for python2.7 is available. judging from the note at the bottom of the "source build" instructions for Groovy: http://wiki.ros.org/groovy/Installation/Debian

this is probably not the best way to do it, but i don't know of a better method at the moment.
