### PR TITLE
change import order of builtins to work when the 'future' package is installed in Python 2

### DIFF
--- a/src/python_qt_binding/binding_helper.py
+++ b/src/python_qt_binding/binding_helper.py
@@ -31,9 +31,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 try:
-    import builtins
-except ImportError:
     import __builtin__ as builtins
+except ImportError:
+    # since the 'future' package provides a 'builtins' module in Python 2
+    # this must not be checked second
+    import builtins
 import os
 import sys
 


### PR DESCRIPTION
Addresses #24.