### PR TITLE
Remove LGPL and GPL from licenses, all code is BSD

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,8 +16,6 @@
   </description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>
-  <license>LGPL</license>
-  <license>GPL</license>
 
   <url>http://ros.org/wiki/python_qt_binding</url>
   <author>Dave Hershberger</author>


### PR DESCRIPTION
I assume this got in by accident, because LGPL and GPL are mentioned in the description, but as all code in this module has a BSD header, this makes it clearer.