### PR TITLE
add QtWidgets for forward compatibility with Qt5

### DIFF
--- a/cmake/sip_helper.cmake
+++ b/cmake/sip_helper.cmake
@@ -11,7 +11,7 @@ assert(PYTHON_EXECUTABLE)
 find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 
 find_program(SIP_EXECUTABLE sip)
-if(NOT SIP_EXECUTABLE_NOTFOUND)
+if(SIP_EXECUTABLE)
   message(STATUS "SIP binding generator available.")
   set(sip_helper_FOUND TRUE)
 else()

--- a/src/python_qt_binding/binding_helper.py
+++ b/src/python_qt_binding/binding_helper.py
@@ -86,6 +86,8 @@ def _select_qt_binding(binding_name=None, binding_order=None):
             if binding_loader:
                 QT_BINDING_VERSION = binding_loader(required_modules, optional_modules)
                 QT_BINDING = binding_name
+                # provide QtWidgets module for forward compatibility with Qt5
+                QT_BINDING_MODULES['QtWidgets'] = QT_BINDING_MODULES['QtGui']
                 break
             else:
                 error_msgs.append("  Binding loader '_load_%s' not found." % binding_name)


### PR DESCRIPTION
This will enable most Python plugins to use the same code base to support Qt 4 as well as 5 with only minimal `try / except` for actual differences between the versions (see e.g. ros-visualization/rqt_common_plugins#359).