### PR TITLE
Fixes failing framework detection on OSX

### DIFF
--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -117,5 +117,8 @@ for ldflag in ldflags.split('\\ '):
 # redirect location of generated library
 makefile._target = '"%s"' % os.path.join(output_dir, makefile._target)
 
+# Force c++11 for qt5
+makefile.extra_cxxflags.append("-std=c++11")
+
 # Generate the Makefile itself
 makefile.generate()

--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -24,6 +24,7 @@ class Configuration(sipconfig.Configuration):
             'qt_threaded': 1,
             'qt_version': QtCore.QT_VERSION,
             'qt_winconfig': 'shared',
+            'qt_framework': 1,
         }
         sipconfig.Configuration.__init__(self, [pyqtconfig])
 


### PR DESCRIPTION
Apparently the framework detection on OSX does not work properly if installed in a non standard location like /usr/local/Cellar/... As Homebrew by default installs Qt5 modules as frameworks and the variable isn't used on Linux and Windows base systems, this probably does not harm.