### PR TITLE
Remove :: from shiboken include path

### DIFF
--- a/cmake/shiboken_helper.cmake
+++ b/cmake/shiboken_helper.cmake
@@ -42,7 +42,7 @@ macro(_shiboken_generator_command VAR GLOBAL TYPESYSTEM INCLUDE_PATH BUILD_DIR)
     foreach(dir ${QT_INCLUDE_DIR})
         set(QT_INCLUDE_DIR_WITH_COLONS "${QT_INCLUDE_DIR_WITH_COLONS}:${dir}")
     endforeach()
-    set(${VAR} ${SHIBOKEN_BINARY} --generatorSet=shiboken --include-paths=${INCLUDE_PATH}:${QT_INCLUDE_DIR_WITH_COLONS} --typesystem-paths=${PYSIDE_TYPESYSTEMS} --output-directory=${BUILD_DIR} ${GLOBAL} ${TYPESYSTEM})
+    set(${VAR} ${SHIBOKEN_BINARY} --generatorSet=shiboken --include-paths=${INCLUDE_PATH}${QT_INCLUDE_DIR_WITH_COLONS} --typesystem-paths=${PYSIDE_TYPESYSTEMS} --output-directory=${BUILD_DIR} ${GLOBAL} ${TYPESYSTEM})
 endmacro()
 
 


### PR DESCRIPTION
The Variable QT_INCLUDE_DIR_WITH_COLONS is iteratively generated
starting with an empty string and adding :${dir}. This always results in
a colon as the first symbol. When combining it with the INCLUDE_PATH
adding a second colon results in :: in the string. The shiboken command
line utility currently has a bug generating an invalid command out of
this (-I without a string). This seems to have been fixed in the
development version already. Still this double colon ins superfluous so
let's remove it.