### PR TITLE
Modifying sip_configure for improper lib names

### DIFF
--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -100,6 +100,8 @@ default_platform_lib_function = sipconfig.SIPModuleMakefile.platform_lib
 
 
 def custom_platform_lib_function(self, clib, framework=0):
+    if not clib or clib.isspace():
+        return None
     if os.path.isabs(clib):
         return clib
     return default_platform_lib_function(self, clib, framework)


### PR DESCRIPTION
This came up when building qt_gui_cpp. When I dropped the boost library find_package, it resolved variables to white space. In turn sip_configure.py added an unnecessary -l to the makefile LIBs command causing make issues.

This adds a check to sip_configure.py for whether the lib name is None, an empty string or whitespace.

For example, when I build qt_gui_cpp this is the diff for the qt_gui_cpp_sip.so Makefile if I ask CMakeLists to ```find_package(Boost...)``` (even if the code doesn't use it) and if I don't.

```
< With find_package(Boost)
> Without find_package(Boost)
< LIBS = -Flib -Llib -F/usr/local/Cellar/qt/5.11.2/lib -L/usr/local/Cellar/qt/5.11.2/lib /usr/local/lib/libboost_filesystem-mt.dylib /usr/local/lib/libboost_system-mt.dylib -framework QtCore -framework DiskArbitration -framework IOKit -framework QtGui -F$$[QT_INSTALL_LIBS] -framework QtCore -framework DiskArbitration -framework IOKit -framework QtWidgets -framework QtPrintSupport
---
> LIBS = -Flib -Llib -F/usr/local/Cellar/qt/5.11.2/lib -L/usr/local/Cellar/qt/5.11.2/lib -l -framework QtCore -framework DiskArbitration -framework IOKit -framework QtGui -F$$[QT_INSTALL_LIBS] -framework QtCore -framework DiskArbitration -framework IOKit -framework QtWidgets -framework QtPrintSupport
```

Or condensed:

```
< LIBS = -Flib -Llib ... libboost_system-mt.dylib -framework QtCore ...
---
> LIBS = -Flib -Llib ... qt/5.11.2/lib -l -framework QtCore...
```

And this is the line from the Makefile with this bug fix

```
< LIBS = -Flib -Llib ... qt/5.11.2/lib -framework QtCore ...
```
 