### PR TITLE
Check for Homebrew's PyQt5 install path

### DIFF
--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -39,6 +39,33 @@ class Configuration(sipconfig.Configuration):
         self.set_build_macros(macros)
 
 
+def get_sip_dir_flags(config):
+    """
+    Get the extra SIP flags needed by the imported qt module, and locate PyQt5 sip install files.
+
+    Note that this normally only includes those flags (-x and -t) that relate to SIP's versioning
+    system.
+    """
+    try:
+        sip_dir = config.pyqt_sip_dir
+        sip_flags = config.pyqt_sip_flags
+        return sip_dir, sip_flags
+    except AttributeError:
+        # sipconfig.Configuration does not have a pyqt_sip_dir or pyqt_sip_flags AttributeError
+        sip_flags = QtCore.PYQT_CONFIGURATION['sip_flags']
+
+        default_sip_dir = os.path.join(sipconfig._pkg_config['default_sip_dir'], 'PyQt5')
+        if os.path.exists(default_sip_dir):
+            return default_sip_dir, sip_flags
+
+        # Homebrew installs sip files here by default
+        default_sip_dir = os.path.join(sipconfig._pkg_config['default_sip_dir'], 'Qt5')
+        if os.path.exists(default_sip_dir):
+            return default_sip_dir, sip_flags
+        raise FileNotFoundError('The sip directory for PyQt5 could not be located. Please ensure' +
+                                ' that PyQt5 is installed')
+
+
 if len(sys.argv) != 8:
     print('usage: %s build-dir sip-file output_dir include_dirs libs lib_dirs ldflags' %
           sys.argv[0])
@@ -55,16 +82,7 @@ build_file = 'pyqtscripting.sbf'
 # Get the PyQt configuration information.
 config = Configuration()
 
-# Get the extra SIP flags needed by the imported qt module.  Note that
-# this normally only includes those flags (-x and -t) that relate to SIP's
-# versioning system.
-try:
-    sip_dir = config.pyqt_sip_dir
-    sip_flags = config.pyqt_sip_flags
-except AttributeError:
-    # sipconfig.Configuration does not have a pyqt_sip_dir or pyqt_sip_flags attribute
-    sip_dir = os.path.join(sipconfig._pkg_config['default_sip_dir'], 'PyQt5')
-    sip_flags = QtCore.PYQT_CONFIGURATION['sip_flags']
+sip_dir, sip_flags = get_sip_dir_flags(config)
 
 try:
     os.makedirs(build_dir)


### PR DESCRIPTION
This modifies the logic in sip_configure to also check for Homebrew's sip file location. Previous ROS2 MacOS instructions said to symlink PyQt5 -> Qt5, but that's not necessary with this PR.