### PR TITLE
Don't add -l prefix if it already exists.

### DIFF
--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -100,7 +100,8 @@ default_platform_lib_function = sipconfig.SIPModuleMakefile.platform_lib
 
 
 def custom_platform_lib_function(self, clib, framework=0):
-    if os.path.isabs(clib):
+    # Only add '-l' if a library doesn't already start with '-l' and is not an absolute path
+    if os.path.isabs(clib) or clib.startswith('-l'):
         return clib
     return default_platform_lib_function(self, clib, framework)
 


### PR DESCRIPTION
Similarly as discussed [here](https://github.com/ros/catkin/pull/975), a `-l` shouldn't be prefixed if a library already has a `-l` prefix. Recently (cmake 3.13) exported its dependency on pthread by adding `-lpthread` to `${Boost_LIBRARIES}`. Using the `sip_helper.py` on cmake 3.13 gives the following error:

```
/usr/sbin/ld: cannot find -l-lpthread
```