### PR TITLE
[Windows][kinetic] Handling build configuration keywords before passed to SIP

### DIFF
--- a/cmake/sip_helper.cmake
+++ b/cmake/sip_helper.cmake
@@ -200,9 +200,11 @@ function(build_sip_binding PROJECT_NAME SIP_FILE)
     set(SIP_BUILD_DIR ${sip_BINARY_DIR}/sip/${PROJECT_NAME})
 
     set(INCLUDE_DIRS ${${PROJECT_NAME}_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
-    set(LIBRARIES ${${PROJECT_NAME}_LIBRARIES})
     set(LIBRARY_DIRS ${${PROJECT_NAME}_LIBRARY_DIRS})
     set(LDFLAGS_OTHER ${${PROJECT_NAME}_LDFLAGS_OTHER})
+
+    # SIP configure doesn't handle build configuration keywords
+    catkin_filter_libraries_for_build_configuration(LIBRARIES ${${PROJECT_NAME}_LIBRARIES})
 
     add_custom_command(
         OUTPUT ${SIP_BUILD_DIR}/Makefile

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>python_qt_binding</name>
   <version>0.3.5</version>
   <description>
@@ -23,12 +23,12 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_export_depend>catkin</buildtool_export_depend>
 
   <build_depend>rosbuild</build_depend>
   <build_depend>qtbase5-dev</build_depend>
-  <build_depend>python-qt5-bindings</build_depend>
 
-  <run_depend>python-qt5-bindings</run_depend>
+  <depend>python-qt5-bindings</depend>
 
   <export>
     <rosbuild cmake_directory="${prefix}/cmake"/>


### PR DESCRIPTION
In Windows build, the generated CMake Config for package could contain the configuration keywords and the sip_configure.py doesn't expect that. So use catkin_filter_libraries_for_build_configuration to normalize the content before it is passed to SIP.

FYI, here is an example what we saw from ${${PROJECT_NAME}_LIBRARIES}
```
"qt_gui_cpp;optimized;C:/opt/rosdeps/x64/lib/boost_filesystem-vc141-mt-x64-1_66.lib;debug;C:/opt/rosdeps/x64/lib/boost_filesystem-vc141-mt-gd-x64-1_66.lib;optimized;C:/opt/rosdeps/x64/lib/boost_system-vc141-mt-x64-1_66.lib;debug;C:/opt/rosdeps/x64/lib/boost_system-vc141-mt-gd-x64-1_66.lib;C:/opt/rosdeps/x64/lib/tinyxml.lib"
```

And without the fix, when it runs into the CMake config with configuration keywords, the linker could fail on the following errors:
```
        link /NOLOGO /DYNAMICBASE /NXCOMPAT /LIBPATH:C:/rviz_ws/devel_isolated/qt_gui_cpp/lib /DLL /MANIFEST /MANIFESTFILE:"C:/rviz_ws/devel_isolated/qt_gui_cpp/lib/site-packages/qt_gui_cpp\libqt_gui_cpp_sip".pyd.manifest /SUBSYSTEM:WINDOWS /INCREMENTAL:NO /OUT:"C:/rviz_ws/devel_isolated/qt_gui_cpp/lib/site-packages/qt_gui_cpp\libqt_gui_cpp_sip".pyd @C:\Users\seanyen\AppData\Local\Temp\nmA71.tmp
LINK : fatal error LNK1181: cannot open input file 'optimized.lib'
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.15.26726\bin\HostX64\x64\link.EXE"' : return code '0x49d'
```

This change is verified in https://aka.ms/ros project.