### PR TITLE
Replace Qt variable in generated Makefile.

### DIFF
--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -139,7 +139,7 @@ makefile.finalise()
 # Replace Qt variables from libraries
 libs = makefile.LIBS.as_list()
 for i in range(len(libs)):
-    libs[i] = libs[i].replace("$$[QT_INSTALL_LIBS]", config.build_macros()["LIBDIR_QT"])
+    libs[i] = libs[i].replace('$$[QT_INSTALL_LIBS]', config.build_macros()['LIBDIR_QT'])
 makefile.LIBS.set(libs)
 
 # Generate the Makefile itself

--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -133,5 +133,14 @@ makefile._target = '"%s"' % os.path.join(output_dir, makefile._target)
 # Force c++11 for qt5
 makefile.extra_cxxflags.append('-std=c++11')
 
+# Finalise the Makefile, preparing it to be saved to disk
+makefile.finalise()
+
+# Replace Qt variables from libraries
+libs = makefile.LIBS.as_list()
+for i in range(len(libs)):
+    libs[i] = libs[i].replace("$$[QT_INSTALL_LIBS]", config.build_macros()["LIBDIR_QT"])
+makefile.LIBS.set(libs)
+
 # Generate the Makefile itself
 makefile.generate()


### PR DESCRIPTION
This PR replaces the `$$[QT_INSTALL_LIBS]` variable, introduced in Qt 5.12.4.

For more info, check [here](http://python.6.x6.nabble.com/Incorrect-Makefile-using-prl-files-from-Qt-5-12-4-td5255962.html).

Note: sipconfig will be [unsupported in sip5](https://www.riverbankcomputing.com/static/Docs/sip/build_system.html), so maybe someone should spend time on replacing sipconfig with something else that is not deprecated?