### PR TITLE
Convert cmake targets to plain libraries to fix linker error

### DIFF
--- a/cmake/sip_helper.cmake
+++ b/cmake/sip_helper.cmake
@@ -205,6 +205,8 @@ function(build_sip_binding PROJECT_NAME SIP_FILE)
 
     # SIP configure doesn't handle build configuration keywords
     catkin_filter_libraries_for_build_configuration(LIBRARIES ${${PROJECT_NAME}_LIBRARIES})
+    # SIP configure doesn't handle CMake targets
+    catkin_replace_imported_library_targets(LIBRARIES ${LIBRARIES})
 
     add_custom_command(
         OUTPUT ${SIP_BUILD_DIR}/Makefile


### PR DESCRIPTION
When `${PROJECT_NAME}_LIBRARIES` contains an imported cmake target, this command will blindly add it to the Makefile with a `-l` option in front. This PR uses a catkin function to extract the library path from imported cmake targets before passing it to the command. 