### PR TITLE
If present, use the sipconfig suggested sip program

### DIFF
--- a/cmake/sip_helper.cmake
+++ b/cmake/sip_helper.cmake
@@ -9,9 +9,19 @@ set(Python_ADDITIONAL_VERSIONS "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}"
 find_package(PythonInterp "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 
-find_program(SIP_EXECUTABLE sip)
+execute_process(
+  COMMAND ${PYTHON_EXECUTABLE} -c "import sipconfig; print(sipconfig.Configuration().sip_bin)"
+  OUTPUT_VARIABLE PYTHON_SIP_EXECUTABLE
+  ERROR_QUIET)
+
+if(PYTHON_SIP_EXECUTABLE)
+  string(STRIP ${PYTHON_SIP_EXECUTABLE} SIP_EXECUTABLE)
+else()
+  find_program(SIP_EXECUTABLE sip)
+endif()
+
 if(SIP_EXECUTABLE)
-  message(STATUS "SIP binding generator available.")
+  message(STATUS "SIP binding generator available at: ${SIP_EXECUTABLE}")
   set(sip_helper_FOUND TRUE)
 else()
   message(WARNING "SIP binding generator NOT available.")


### PR DESCRIPTION
The value of `SIP_EXECUTABLE` is not used in the sip invocation within `sip_configure.py`. Instead, the `sip_bin` configuration is loaded from the `sipconfig` Python module.

Instead of assuming that the sip executable is called `sip` in the CMake which detects whether the sip binding generator is present, try to find the executable in the same way that `sip_configure.py` will.