### PR TITLE
use condition attributes to specify Python 2 and 3 dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,8 @@
   <build_depend>rosbuild</build_depend>
   <build_depend>qtbase5-dev</build_depend>
 
-  <depend>python-qt5-bindings</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python-qt5-bindings</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3-qt5-bindings</depend>
 
   <export>
     <rosbuild cmake_directory="${prefix}/cmake"/>


### PR DESCRIPTION
I am following the same convention how [`catkin`](https://github.com/ros/catkin/pull/1025) chooses the dependencies based on Python version, so different rosdep keys can be selected depending on the build environment.