### PR TITLE
Use magic $(MAKE) variable to suppress build warning

### DIFF
--- a/cmake/sip_helper.cmake
+++ b/cmake/sip_helper.cmake
@@ -99,7 +99,7 @@ function(build_sip_binding PROJECT_NAME SIP_FILE)
     if(WIN32)
       set(MAKE_EXECUTABLE NMake.exe)
     else()
-      set(MAKE_EXECUTABLE make)
+      set(MAKE_EXECUTABLE "\$(MAKE)")
     endif()
 
     add_custom_command(


### PR DESCRIPTION
According to the [gnu make documentation](https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html#MAKE-Variable), a subprocess make should use the `$(MAKE)` variable or `+make` to tell the parent `make` process that the child is actually a `make` process as well.

This is required to suppress the warning:
`warning: jobserver unavailable: using -j1. Add `+' to parent make rule.`