### PR TITLE
add sip5 binding install directory check

### DIFF
--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -61,6 +61,12 @@ def get_sip_dir_flags(config):
         # sipconfig.Configuration does not have a pyqt_sip_dir or pyqt_sip_flags AttributeError
         sip_flags = QtCore.PYQT_CONFIGURATION['sip_flags']
 
+        # Archlinux installs sip files here by default
+        default_sip_dir = os.path.join(sipconfig._pkg_config['default_mod_dir'], 'PyQt5', 'bindings')
+        if os.path.exists(default_sip_dir):
+            return default_sip_dir, sip_flags
+
+        # sip4 installs here by default
         default_sip_dir = os.path.join(sipconfig._pkg_config['default_sip_dir'], 'PyQt5')
         if os.path.exists(default_sip_dir):
             return default_sip_dir, sip_flags


### PR DESCRIPTION
resolves #80 
affected downstream issues:
https://github.com/ros-noetic-arch/ros-noetic-python-qt-binding/issues/2
https://github.com/ros-melodic-arch/ros-melodic-rviz/issues/9

Basically adds the sip5 default binding install directory to the check, since this will be the new place of bindings and some distros have already switched causing errors on those systems without adding this check.
Added comments in code for clarity.