### PR TITLE
Shorten some excessively long lines of CMake

### DIFF
--- a/cmake/shiboken_helper.cmake
+++ b/cmake/shiboken_helper.cmake
@@ -61,14 +61,22 @@ endif()
 macro(_shiboken_generator_command VAR GLOBAL TYPESYSTEM INCLUDE_PATH BUILD_DIR)
   # Add includes from current directory, Qt, PySide and compiler specific dirs
   get_directory_property(SHIBOKEN_HELPER_INCLUDE_DIRS INCLUDE_DIRECTORIES)
-  list(APPEND SHIBOKEN_HELPER_INCLUDE_DIRS ${QT_INCLUDE_DIR} ${PYSIDE_INCLUDE_DIR} ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+  list(APPEND SHIBOKEN_HELPER_INCLUDE_DIRS
+    ${QT_INCLUDE_DIR}
+    ${PYSIDE_INCLUDE_DIR}
+    ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
   # See ticket https://code.ros.org/trac/ros-pkg/ticket/5219
   set(SHIBOKEN_HELPER_INCLUDE_DIRS_WITH_COLONS "")
   foreach(dir ${SHIBOKEN_HELPER_INCLUDE_DIRS})
     set(SHIBOKEN_HELPER_INCLUDE_DIRS_WITH_COLONS "${SHIBOKEN_HELPER_INCLUDE_DIRS_WITH_COLONS}:${dir}")
   endforeach()
   string(REPLACE ";" ":" INCLUDE_PATH_WITH_COLONS "${INCLUDE_PATH}")
-  set(${VAR} ${SHIBOKEN_BINARY} --generatorSet=shiboken --enable-pyside-extensions --include-paths=${INCLUDE_PATH_WITH_COLONS}${SHIBOKEN_HELPER_INCLUDE_DIRS_WITH_COLONS} --typesystem-paths=${PYSIDE_TYPESYSTEMS} --output-directory=${BUILD_DIR} ${GLOBAL} ${TYPESYSTEM})
+  set(${VAR} ${SHIBOKEN_BINARY}
+    --generatorSet=shiboken
+    --enable-pyside-extensions
+    --include-paths=${INCLUDE_PATH_WITH_COLONS}${SHIBOKEN_HELPER_INCLUDE_DIRS_WITH_COLONS}
+    --typesystem-paths=${PYSIDE_TYPESYSTEMS}
+    --output-directory=${BUILD_DIR} ${GLOBAL} ${TYPESYSTEM})
 endmacro()
 
 

--- a/cmake/sip_helper.cmake
+++ b/cmake/sip_helper.cmake
@@ -81,7 +81,8 @@ function(build_sip_binding PROJECT_NAME SIP_FILE)
 
     add_custom_command(
         OUTPUT ${SIP_BUILD_DIR}/Makefile
-        COMMAND ${PYTHON_EXECUTABLE} ${sip_SIP_CONFIGURE} ${SIP_BUILD_DIR} ${SIP_FILE} ${sip_LIBRARY_DIR} \"${INCLUDE_DIRS}\" \"${LIBRARIES}\" \"${LIBRARY_DIRS}\" \"${LDFLAGS_OTHER}\"
+        COMMAND ${PYTHON_EXECUTABLE} ${sip_SIP_CONFIGURE} ${SIP_BUILD_DIR} ${SIP_FILE} ${sip_LIBRARY_DIR}
+          \"${INCLUDE_DIRS}\" \"${LIBRARIES}\" \"${LIBRARY_DIRS}\" \"${LDFLAGS_OTHER}\"
         DEPENDS ${sip_SIP_CONFIGURE} ${SIP_FILE} ${sip_DEPENDS}
         WORKING_DIRECTORY ${sip_SOURCE_DIR}
         COMMENT "Running SIP generator for ${PROJECT_NAME} Python bindings..."


### PR DESCRIPTION
The line length enforcement in ament_lint_cmake has been broken for some time, but will be fixed by ament/ament_lint#236. This change brings this package into compliance with a 120 column limit.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13645)](http://ci.ros2.org/job/ci_linux/13645/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8525)](http://ci.ros2.org/job/ci_linux-aarch64/8525/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11360)](http://ci.ros2.org/job/ci_osx/11360/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13709)](http://ci.ros2.org/job/ci_windows/13709/)