### PR TITLE
Use PyQt5 module path to find SIP bindings

### DIFF
--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 import sipconfig
+import PyQt5
 from PyQt5 import QtCore
 
 libqt5_rename = False
@@ -62,7 +63,7 @@ def get_sip_dir_flags(config):
         sip_flags = QtCore.PYQT_CONFIGURATION['sip_flags']
 
         # Archlinux installs sip files here by default
-        default_sip_dir = os.path.join(sipconfig._pkg_config['default_mod_dir'], 'PyQt5', 'bindings')
+        default_sip_dir = os.path.join(PyQt5.__path__[0], 'bindings')
         if os.path.exists(default_sip_dir):
             return default_sip_dir, sip_flags
 


### PR DESCRIPTION
`sipconfig._pkg_config['default_mod_dir']` is currently used to find the PyQt5 SIP bindings, but this location is determined by where SIP is installed, which may not be the same as where PyQt5 is installed. A real world example of this is in Nix, where each package is installed to a separate isolated directory. Instead, we can use `PyQt5.__path__[0]`, which will always point to the location of the PyQt5 module. This approach was based on [python-poppler-qt5](https://github.com/frescobaldi/python-poppler-qt5/blob/85adeddbc4658cd8b2daaaa067484ba9b46ad82c/project.py#L21). 

I made this PR against `melodic-devel` because it includes #95. I would appreciate it if both #95 and this PR could be included in a ROS2 release at some point.

cc @mikepurvis