### PR TITLE
Use PyQt5 module path to find SIP bindings (ROS 2)

### DIFF
--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -61,6 +61,12 @@ def get_sip_dir_flags(config):
         # sipconfig.Configuration does not have a pyqt_sip_dir or pyqt_sip_flags AttributeError
         sip_flags = QtCore.PYQT_CONFIGURATION['sip_flags']
 
+        # Archlinux installs sip files here by default
+        default_sip_dir = os.path.join(sipconfig._pkg_config['default_mod_dir'], 'PyQt5', 'bindings')
+        if os.path.exists(default_sip_dir):
+            return default_sip_dir, sip_flags
+
+        # sip4 installs here by default
         default_sip_dir = os.path.join(sipconfig._pkg_config['default_sip_dir'], 'PyQt5')
         if os.path.exists(default_sip_dir):
             return default_sip_dir, sip_flags

--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 import sys
 
+import PyQt5
 from PyQt5 import QtCore
 import sipconfig
 
@@ -62,7 +63,7 @@ def get_sip_dir_flags(config):
         sip_flags = QtCore.PYQT_CONFIGURATION['sip_flags']
 
         # Archlinux installs sip files here by default
-        default_sip_dir = os.path.join(sipconfig._pkg_config['default_mod_dir'], 'PyQt5', 'bindings')
+        default_sip_dir = os.path.join(PyQt5.__path__[0], 'bindings')
         if os.path.exists(default_sip_dir):
             return default_sip_dir, sip_flags
 


### PR DESCRIPTION
This applies #95 and #105 to the main branch to be included in a ROS 2 release.