### PR TITLE
1.0.8 (Galactic)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package python_qt_binding
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.0.8 (2021-12-06)
+------------------
+* Replace PythonInterp to Python3 COMPONENTS (`#110 <https://github.com/ros-visualization/python_qt_binding/issues/110>`_)
+* fuerte-devel is too new for ROS Electric (`#101 <https://github.com/ros-visualization/python_qt_binding/issues/101>`_)
+* Contributors: Homalozoa X, Shane Loretz
+
 1.0.7 (2021-03-18)
 ------------------
 * Add repo README

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>python_qt_binding</name>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
   <description>
     This stack provides Python bindings for Qt.
     There are two providers: pyside and pyqt.  PySide2 is available under


### PR DESCRIPTION
Full diff: https://github.com/ros-visualization/python_qt_binding/compare/1.0.7...release/1.0.8

I will fast-forward merge this PR and trigger the release upon maintainer approval.