### PR TITLE
add pyqt imports to mimic python_qt_bindings

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,9 +26,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>qtbase5-dev</build_depend>
-  <build_depend>python3-qt5-bindings</build_depend>
+  <build_depend>python3_qtpy</build_depend>
+  <build_depend>python3-pyqt5</build_depend>
 
-  <exec_depend>python3-qt5-bindings</exec_depend>
+  <exec_depend>python3-qtpy</exec_depend>
+  <exec_depend>python3-pyqt5</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/src/python_qt_binding/Qt3DAnimation.py
+++ b/src/python_qt_binding/Qt3DAnimation.py
@@ -1,0 +1,1 @@
+from qtpy.Qt3DAnimation import *  # noqa: F401, F403

--- a/src/python_qt_binding/Qt3DCore.py
+++ b/src/python_qt_binding/Qt3DCore.py
@@ -1,0 +1,1 @@
+from qtpy.Qt3DCore import *  # noqa: F401, F403

--- a/src/python_qt_binding/Qt3DExtras.py
+++ b/src/python_qt_binding/Qt3DExtras.py
@@ -1,0 +1,1 @@
+from qtpy.Qt3DExtras import *  # noqa: F401, F403

--- a/src/python_qt_binding/Qt3DInput.py
+++ b/src/python_qt_binding/Qt3DInput.py
@@ -1,0 +1,1 @@
+from qtpy.Qt3DInput import *  # noqa: F401, F403

--- a/src/python_qt_binding/Qt3DLogic.py
+++ b/src/python_qt_binding/Qt3DLogic.py
@@ -1,0 +1,1 @@
+from qtpy.Qt3DLogic import *  # noqa: F401, F403

--- a/src/python_qt_binding/Qt3DRender.py
+++ b/src/python_qt_binding/Qt3DRender.py
@@ -1,0 +1,1 @@
+from qtpy.Qt3DRender import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtCharts.py
+++ b/src/python_qt_binding/QtCharts.py
@@ -1,0 +1,1 @@
+from qtpy.QtCharts import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtCore.py
+++ b/src/python_qt_binding/QtCore.py
@@ -1,0 +1,1 @@
+from qtpy.QtCore import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtDBus.py
+++ b/src/python_qt_binding/QtDBus.py
@@ -1,0 +1,1 @@
+from qtpy.QtDBus import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtDataVisualization.py
+++ b/src/python_qt_binding/QtDataVisualization.py
@@ -1,0 +1,1 @@
+from qtpy.QtDataVisualization import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtDesigner.py
+++ b/src/python_qt_binding/QtDesigner.py
@@ -1,0 +1,1 @@
+from qtpy.QtDesigner import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtGui.py
+++ b/src/python_qt_binding/QtGui.py
@@ -1,0 +1,1 @@
+from qtpy.QtGui import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtHelp.py
+++ b/src/python_qt_binding/QtHelp.py
@@ -1,0 +1,1 @@
+from qtpy.QtHelp import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtLocation.py
+++ b/src/python_qt_binding/QtLocation.py
@@ -1,0 +1,1 @@
+from qtpy.QtLocation import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtMultimedia.py
+++ b/src/python_qt_binding/QtMultimedia.py
@@ -1,0 +1,1 @@
+from qtpy.QtMultimedia import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtMultimediaWidgets.py
+++ b/src/python_qt_binding/QtMultimediaWidgets.py
@@ -1,0 +1,1 @@
+from qtpy.QtMultimediaWidgets import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtNetwork.py
+++ b/src/python_qt_binding/QtNetwork.py
@@ -1,0 +1,1 @@
+from qtpy.QtNetwork import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtNetworkAuth.py
+++ b/src/python_qt_binding/QtNetworkAuth.py
@@ -1,0 +1,1 @@
+from qtpy.QtNetworkAuth import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtOpenGL.py
+++ b/src/python_qt_binding/QtOpenGL.py
@@ -1,0 +1,1 @@
+from qtpy.QtOpenGL import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtOpenGLWidgets.py
+++ b/src/python_qt_binding/QtOpenGLWidgets.py
@@ -1,0 +1,1 @@
+from qtpy.QtOpenGLWidgets import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtPositioning.py
+++ b/src/python_qt_binding/QtPositioning.py
@@ -1,0 +1,1 @@
+from qtpy.QtPositioning import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtPrintSupport.py
+++ b/src/python_qt_binding/QtPrintSupport.py
@@ -1,0 +1,1 @@
+from qtpy.QtPrintSupport import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtQml.py
+++ b/src/python_qt_binding/QtQml.py
@@ -1,0 +1,1 @@
+from qtpy.QtQml import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtQuick.py
+++ b/src/python_qt_binding/QtQuick.py
@@ -1,0 +1,1 @@
+from qtpy.QtQuick import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtQuickWidgets.py
+++ b/src/python_qt_binding/QtQuickWidgets.py
@@ -1,0 +1,1 @@
+from qtpy.QtQuickWidgets import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtRemoteObjects.py
+++ b/src/python_qt_binding/QtRemoteObjects.py
@@ -1,0 +1,1 @@
+from qtpy.QtRemoteObjects import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtSensors.py
+++ b/src/python_qt_binding/QtSensors.py
@@ -1,0 +1,1 @@
+from qtpy.QtSensors import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtSerialPort.py
+++ b/src/python_qt_binding/QtSerialPort.py
@@ -1,0 +1,1 @@
+from qtpy.QtSerialPort import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtSql.py
+++ b/src/python_qt_binding/QtSql.py
@@ -1,0 +1,1 @@
+from qtpy.QtSql import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtSvg.py
+++ b/src/python_qt_binding/QtSvg.py
@@ -1,0 +1,1 @@
+from qtpy.QtSvg import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtTest.py
+++ b/src/python_qt_binding/QtTest.py
@@ -1,0 +1,1 @@
+from qtpy.QtTest import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtTextToSpeech.py
+++ b/src/python_qt_binding/QtTextToSpeech.py
@@ -1,0 +1,1 @@
+from qtpy.QtTextToSpeech import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtWebChannel.py
+++ b/src/python_qt_binding/QtWebChannel.py
@@ -1,0 +1,1 @@
+from qtpy.QtWebChannel import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtWebEngine.py
+++ b/src/python_qt_binding/QtWebEngine.py
@@ -1,0 +1,1 @@
+from qtpy.QtWebEngine import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtWebEngineCore.py
+++ b/src/python_qt_binding/QtWebEngineCore.py
@@ -1,0 +1,1 @@
+from qtpy.QtWebEngineCore import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtWebEngineQuick.py
+++ b/src/python_qt_binding/QtWebEngineQuick.py
@@ -1,0 +1,1 @@
+from qtpy.QtWebEngineQuick import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtWebEngineWidgets.py
+++ b/src/python_qt_binding/QtWebEngineWidgets.py
@@ -1,0 +1,1 @@
+from qtpy.QtWebEngineWidgets import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtWebSockets.py
+++ b/src/python_qt_binding/QtWebSockets.py
@@ -1,0 +1,1 @@
+from qtpy.QtWebSockets import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtWidgets.py
+++ b/src/python_qt_binding/QtWidgets.py
@@ -1,0 +1,1 @@
+from qtpy.QtWidgets import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtWinExtras.py
+++ b/src/python_qt_binding/QtWinExtras.py
@@ -1,0 +1,1 @@
+from qtpy.QtWinExtras import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtXml.py
+++ b/src/python_qt_binding/QtXml.py
@@ -1,0 +1,1 @@
+from qtpy.QtXml import *  # noqa: F401, F403

--- a/src/python_qt_binding/QtXmlPatterns.py
+++ b/src/python_qt_binding/QtXmlPatterns.py
@@ -1,0 +1,1 @@
+from qtpy.QtXmlPatterns import *  # noqa: F401, F403

--- a/src/python_qt_binding/__init__.py
+++ b/src/python_qt_binding/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright (c) 2011, Dirk Thomas, Dorian Scholz, TU Darmstadt
+#               2022, Christoph Hellmann Santos, Fraunhofer IPA
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,39 +31,12 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""
-Abstraction for different Python Qt bindings.
 
-Supported Python Qt 5 bindings are PyQt and PySide.
-The Qt modules can be imported like this:
+import warnings
+from qtpy.uic import loadUi  # noqa: F401
 
-from python_qt_binding.QtCore import QObject
-from python_qt_binding import QtGui, loadUi
-
-The name of the selected binding is available in QT_BINDING.
-The version of the selected binding is available in QT_BINDING_VERSION.
-All available Qt modules are listed in QT_BINDING_MODULES.
-
-The default binding order ('pyqt', 'pyside') can be overridden with a
-SELECT_QT_BINDING_ORDER attribute on sys:
-  setattr(sys, 'SELECT_QT_BINDING_ORDER', [FIRST_NAME, NEXT_NAME, ..])
-
-A specific binding can be selected with a SELECT_QT_BINDING attribute on sys:
-  setattr(sys, 'SELECT_QT_BINDING', MY_BINDING_NAME)
-"""
-
-import sys
-
-from python_qt_binding.binding_helper import loadUi  # noqa: F401
-from python_qt_binding.binding_helper import QT_BINDING  # noqa: F401
-from python_qt_binding.binding_helper import QT_BINDING_MODULES
-from python_qt_binding.binding_helper import QT_BINDING_VERSION  # noqa: F401
-
-# register binding modules as sub modules of this package (python_qt_binding) for easy importing
-for module_name, module in QT_BINDING_MODULES.items():
-    sys.modules[__name__ + '.' + module_name] = module
-    setattr(sys.modules[__name__], module_name, module)
-    del module_name
-    del module
-
-del sys
+_DEPRECATION_MESSAGE = ("Using python_qt_bindings package in python is deprecated."
+                        "The package should be replaced by python3-qtpy system dep."
+                        "python_qt_bindings will only cater generation scrips in the future.")
+warnings.warn(_DEPRECATION_MESSAGE,
+              DeprecationWarning, 2)


### PR DESCRIPTION
This PR adds pyqt as wrapper for the different Python QT libraries and versions.
This is related to #114.

The python_qt_binding python import is mapped to qtpy. The python_qt_binding import is marked as depreceated. Users should switch to directly use python3-qtpy. 

CI will only pass once new rosdep keys have been merged.