### PR TITLE
Remove pyqt from default binding order for macOS

### DIFF
--- a/src/python_qt_binding/binding_helper.py
+++ b/src/python_qt_binding/binding_helper.py
@@ -36,6 +36,7 @@ except ImportError:
     # since the 'future' package provides a 'builtins' module in Python 2
     # this must not be checked second
     import builtins
+import platform
 import os
 import sys
 import traceback
@@ -50,7 +51,11 @@ def _select_qt_binding(binding_name=None, binding_order=None):
     global QT_BINDING, QT_BINDING_VERSION
 
     # order of default bindings can be changed here
-    DEFAULT_BINDING_ORDER = ['pyqt', 'pyside']
+    if platform.system() == 'Darwin':
+        DEFAULT_BINDING_ORDER = ['pyside']
+    else:
+        DEFAULT_BINDING_ORDER = ['pyqt', 'pyside']
+
     binding_order = binding_order or DEFAULT_BINDING_ORDER
 
     # determine binding preference


### PR DESCRIPTION
This PR removes `pyqt` from the list of default bindings when running macOS ('Darwin'). 

Partial fix for #103. Details in https://github.com/ros-visualization/python_qt_binding/issues/103#issuecomment-1231062249 for accompanying changes required in https://github.com/ros-visualization/qt_gui_core.

The brew formula for `pyside@2` is keg only, to build and run using PySide2 set the environment variables:

```zsh
export CMAKE_PREFIX_PATH=/usr/local/opt/pyside@2:$CMAKE_PREFIX_PATH
export PATH=/usr/local/opt/pyside@2/bin:$PATH
export PYTHONPATH=$PYTHONPATH:/usr/local/opt/pyside@2/lib/python3.10/site-packages
```
