### PR TITLE
Demote missing SIP message from WARNING to STATUS

### DIFF
--- a/cmake/sip_helper.cmake
+++ b/cmake/sip_helper.cmake
@@ -22,7 +22,7 @@ if(SIP_EXECUTABLE)
   message(STATUS "SIP binding generator available at: ${SIP_EXECUTABLE}")
   set(sip_helper_FOUND TRUE)
 else()
-  message(WARNING "SIP binding generator NOT available.")
+  message(STATUS "SIP binding generator NOT available.")
   set(sip_helper_NOTFOUND TRUE)
 endif()
 


### PR DESCRIPTION
It's becoming increasingly normal to use Shiboken instead of SIP, so it shouldn't be a warning when it isn't found.

We'll still get an error message if NONE of the binding generators are available: https://github.com/ros-visualization/qt_gui_core/blob/50bbbb5d17454a4492a3b01894e140d18589a543/qt_gui_cpp/CMakeLists.txt#L65-L68

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=18092)](http://ci.ros2.org/job/ci_linux/18092/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=12624)](http://ci.ros2.org/job/ci_linux-aarch64/12624/)
* Linux-rhel8 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=317)](http://ci.ros2.org/job/ci_linux-rhel/317/)
* Linux-rhel9 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=318)](http://ci.ros2.org/job/ci_linux-rhel/318/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=18736)](http://ci.ros2.org/job/ci_windows/18736/)