### PR TITLE
Fix flake8 linter regression

### DIFF
--- a/src/python_qt_binding/binding_helper.py
+++ b/src/python_qt_binding/binding_helper.py
@@ -36,8 +36,8 @@ except ImportError:
     # since the 'future' package provides a 'builtins' module in Python 2
     # this must not be checked second
     import builtins
-import platform
 import os
+import platform
 import sys
 import traceback
 


### PR DESCRIPTION
Happening on all ros2 nightlies ([linux-debug](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/2592/), [aarch-debug](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_debug/2281/), [windows-debug](https://ci.ros2.org/view/nightly/job/nightly_win_deb/2653/))

Error message:
```
Import statements are in the wrong order. 'import os' should be before 'import platform':
import os
```

This was introduced in: https://github.com/ros-visualization/python_qt_binding/pull/118