### PR TITLE
Fix to allow ninja to use make for generators (#123)

### DIFF
--- a/cmake/sip_helper.cmake
+++ b/cmake/sip_helper.cmake
@@ -93,7 +93,9 @@ function(build_sip_binding PROJECT_NAME SIP_FILE)
     if(WIN32)
       set(MAKE_EXECUTABLE NMake.exe)
     else()
-      set(MAKE_EXECUTABLE "\$(MAKE)")
+      find_program(MAKE_PROGRAM NAMES make)
+      message(STATUS "Found required make: ${MAKE_PROGRAM}")
+      set(MAKE_EXECUTABLE ${MAKE_PROGRAM})
     endif()
 
     add_custom_command(


### PR DESCRIPTION
This is a backport of upstream commit ade88c56e27bcb74732e8bd8475fbda00d722355.  This allows ROS Humble LTS to be compiled with Ninja.

Without this, colcon build with an environment variable `CMAKE_GENERATOR=Ninja` for packages depending on `python_qt_binding` fails with the following error.
```
Starting >>> qt_gui_cpp
-- The C compiler identification is GNU 12.3.0
-- The CXX compiler identification is GNU 12.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/lib/ccache/gcc-12 - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done      
-- Check for working CXX compiler: /usr/lib/ccache/g++-12 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ament_cmake: 1.3.5 (/home/yashi/work/yoshida/humble/install/share/ament_cmake/cmake)
-- Found Python3: /usr/bin/python3 (found version "3.11.5") found components: Interpreter 
-- Override CMake install command with custom implementation using symlinks instead of copying resources
-- Found pluginlib: 5.1.0 (/home/yashi/work/yoshida/humble/install/share/pluginlib/cmake)
-- Found TinyXML2 via Config file: /usr/lib/x86_64-linux-gnu/cmake/tinyxml2
-- Found TinyXML2 via Config file: /usr/lib/x86_64-linux-gnu/cmake/tinyxml2
-- Found python_qt_binding: 1.1.1 (/home/yashi/work/yoshida/humble/install/share/python_qt_binding/cmake)
CMake Warning (dev) at /home/yashi/work/yoshida/humble/install/share/python_qt_binding/cmake/shiboken_helper.cmake:1 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  src/qt_gui_cpp_shiboken/CMakeLists.txt:43 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.11.5", minimum required is "3.3") 
-- PySide2Config: Using default python: .cpython-311-x86_64-linux-gnu
-- Found PySide2 version 5.15.10
-- Using PYSIDE_INCLUDE_DIR: /usr/lib/../include/PySide2
-- Using PYSIDE_LIBRARY: /usr/lib/x86_64-linux-gnu/libpyside2.cpython-311-x86_64-linux-gnu.so.5.15.10
CMake Warning (dev) at /home/yashi/work/yoshida/humble/install/share/python_qt_binding/cmake/shiboken_helper.cmake:37 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  src/qt_gui_cpp_shiboken/CMakeLists.txt:43 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.11.so (found suitable version "3.11.5", minimum required is "3.11") 
-- Shiboken binding generator NOT available.
-- Found Python3: /usr/include/python3.11 (found version "3.11.5") found components: Development Development.Module Development.Embed 
-- Found python_qt_binding: 1.1.1 (/home/yashi/work/yoshida/humble/install/share/python_qt_binding/cmake)
-- Found Python3: /usr/bin/python3 (found suitable version "3.11.5", minimum required is "3.11.5") found components: Interpreter Development Development.Module Development.Embed 
-- SIP binding generator available at: /usr/bin/sip
-- Python binding generators: sip
-- Configuring done (1.1s)                     
-- Generating done (0.0s)
CMake Error:
  Running

   '/usr/bin/ninja' '-C' '/home/yashi/work/yoshida/test-rqt/build/qt_gui_cpp' '-t' 'recompact'

  failed with:

   ninja: error: build.ninja:526: bad $-escape (literal $ must be written as $$)

  



CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_CLOUD_CLIENT


CMake Generate step failed.  Build files cannot be regenerated correctly.
ninja: error: loading 'build.ninja': No such file or directory
```