### PR TITLE
Switch to C++17 for SIP and Shiboken

### DIFF
--- a/cmake/shiboken_helper.cmake
+++ b/cmake/shiboken_helper.cmake
@@ -70,6 +70,7 @@ macro(_shiboken_generator_command VAR GLOBAL TYPESYSTEM INCLUDE_PATH BUILD_DIR)
   set(${VAR} ${SHIBOKEN_BINARY}
     --generatorSet=shiboken
     --enable-pyside-extensions
+    -std=c++17
     --include-paths=${INCLUDE_PATH_WITH_COLONS}${SHIBOKEN_HELPER_INCLUDE_DIRS_WITH_COLONS}
     --typesystem-paths=${PYSIDE_TYPESYSTEMS}
     --output-directory=${BUILD_DIR} ${GLOBAL} ${TYPESYSTEM})

--- a/cmake/sip_configure.py
+++ b/cmake/sip_configure.py
@@ -209,14 +209,14 @@ for ldflag in ldflags.split('\\ '):
 # redirect location of generated library
 makefile._target = '"%s"' % os.path.join(output_dir, makefile._target)
 
-# Force c++14
+# Force c++17
 if sys.platform == 'win32':
-    makefile.extra_cxxflags.append('/std:c++14')
+    makefile.extra_cxxflags.append('/std:c++17')
     # The __cplusplus flag is not properly set on Windows for backwards
     # compatibilty. This flag sets it correctly
     makefile.CXXFLAGS.append('/Zc:__cplusplus')
 else:
-    makefile.extra_cxxflags.append('-std=c++14')
+    makefile.extra_cxxflags.append('-std=c++17')
 
 # Finalise the Makefile, preparing it to be saved to disk
 makefile.finalise()


### PR DESCRIPTION
Relates to https://github.com/ros-visualization/qt_gui_core/pull/288

Relates to https://github.com/ros/pluginlib/pull/254

Switch to C++17 to be able to use `std::filesystem` when building SIP or Shiboken bindings.

I'm doing this mainly for `qt_gui_core` and I didn't seem to need the change for Shiboken, but we'll probably hit the same issue as we migrate everything else to C++17's `std::filesystem`. See the corresponding docs for Shiboken: https://doc.qt.io/qtforpython-5/shiboken2/shibokengenerator.html#usage.

I think we can merge this without negatively affecting anything.