### PR TITLE
Skip running the tests on Windows Debug.

### DIFF
--- a/test/test_imports.py
+++ b/test/test_imports.py
@@ -12,22 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 
+import pytest
+
+
+@pytest.mark.skipif(sys.platform == 'win32' and sys.executable.endswith('python_d.exe'),
+                    reason='Skipping test on Windows Debug')
 def test_import_qtcore():
     from python_qt_binding import QtCore
     assert QtCore is not None
 
 
+@pytest.mark.skipif(sys.platform == 'win32' and sys.executable.endswith('python_d.exe'),
+                    reason='Skipping test on Windows Debug')
 def test_import_qtgui():
     from python_qt_binding import QtGui
     assert QtGui is not None
 
 
+@pytest.mark.skipif(sys.platform == 'win32' and sys.executable.endswith('python_d.exe'),
+                    reason='Skipping test on Windows Debug')
 def test_import_qtwidgets():
     from python_qt_binding import QtWidgets
     assert QtWidgets is not None
 
 
+@pytest.mark.skipif(sys.platform == 'win32' and sys.executable.endswith('python_d.exe'),
+                    reason='Skipping test on Windows Debug')
 def test_import_qtobject():
     from python_qt_binding.QtCore import QObject
     assert QObject is not None

--- a/test/test_imports.py
+++ b/test/test_imports.py
@@ -12,34 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.machinery
 import sys
 
 import pytest
 
 
-@pytest.mark.skipif(sys.platform == 'win32' and sys.executable.endswith('python_d.exe'),
-                    reason='Skipping test on Windows Debug')
+# If this is running on a Python Windows interpreter built in debug mode, skip running tests
+# because we do not have the debug libraries available for PyQt.  It is surprisingly tricky to
+# discover whether the current interpreter was built in debug mode (note that this is different
+# than running the interpreter in debug mode, i.e. PYTHONDEBUG=1).  The only non-deprecated way
+# we've found is to look for _d.pyd in the extension suffixes, so that is what we do here.
+is_windows_debug = sys.platform == 'win32' and '_d.pyd' in importlib.machinery.EXTENSION_SUFFIXES
+
+
+@pytest.mark.skipif(is_windows_debug, reason='Skipping test on Windows Debug')
 def test_import_qtcore():
     from python_qt_binding import QtCore
     assert QtCore is not None
 
 
-@pytest.mark.skipif(sys.platform == 'win32' and sys.executable.endswith('python_d.exe'),
-                    reason='Skipping test on Windows Debug')
+@pytest.mark.skipif(is_windows_debug, reason='Skipping test on Windows Debug')
 def test_import_qtgui():
     from python_qt_binding import QtGui
     assert QtGui is not None
 
 
-@pytest.mark.skipif(sys.platform == 'win32' and sys.executable.endswith('python_d.exe'),
-                    reason='Skipping test on Windows Debug')
+@pytest.mark.skipif(is_windows_debug, reason='Skipping test on Windows Debug')
 def test_import_qtwidgets():
     from python_qt_binding import QtWidgets
     assert QtWidgets is not None
 
 
-@pytest.mark.skipif(sys.platform == 'win32' and sys.executable.endswith('python_d.exe'),
-                    reason='Skipping test on Windows Debug')
+@pytest.mark.skipif(is_windows_debug, reason='Skipping test on Windows Debug')
 def test_import_qtobject():
     from python_qt_binding.QtCore import QObject
     assert QObject is not None


### PR DESCRIPTION
When we run CI on Windows Debug, Python expects to be able to find compiled libraries with an extra _d in their filename that contains the debugging ABI.

However, we don't currently have a debug library available for PyQt5, and thus when running under Windows Debug, the tests cannot succeed.  While we could build a debug library for PyQt5, that is actually a massive undertaking. Instead, just skip these tests when we are on Windows Debug. While that loses us a bit of coverage, it won't matter much; we are still testing this on Windows (Release) and on Linux.

The way in which this patch determines that this is a Windows Debug interpreter is a little chintzy.  It just uses the fact that the binary is named python_d.exe to discover that. I couldn't find another way to tell if this was a debug interpreter, but I am open to other ideas.