### PR TITLE
Fix: Standardize Default Qt Binding Order to Prioritize PyQt

### DIFF
--- a/src/python_qt_binding/binding_helper.py
+++ b/src/python_qt_binding/binding_helper.py
@@ -51,10 +51,7 @@ def _select_qt_binding(binding_name=None, binding_order=None):
     global QT_BINDING, QT_BINDING_VERSION
 
     # order of default bindings can be changed here
-    if platform.system() == 'Darwin':
-        DEFAULT_BINDING_ORDER = ['pyside']
-    else:
-        DEFAULT_BINDING_ORDER = ['pyqt', 'pyside']
+    DEFAULT_BINDING_ORDER = ['pyqt', 'pyside']
 
     binding_order = binding_order or DEFAULT_BINDING_ORDER
 


### PR DESCRIPTION
### 📝 Summary of Change

This Pull Request standardizes the default Qt binding selection logic within `python_qt_binding` by removing the platform-specific check for macOS (Darwin).

The default binding order is now uniformly set to `['pyqt', 'pyside']` for all operating systems.

### 🐛 Problem Solved

Previously, the logic for macOS was restricted:

``` python
if platform.system() == 'Darwin':
    DEFAULT_BINDING_ORDER = ['pyside']
else:
    DEFAULT_BINDING_ORDER = ['pyqt', 'pyside']
```

This restriction caused GUI tools like `rqt` to fail on macOS if the PySide2 package was not found, even if PyQt was correctly installed:

    ModuleNotFoundError: No module named 'PySide2'

The system was prevented from falling back to the available PyQt binding.

### ✅ Solution (Code Change)

The platform-specific conditional logic is replaced with the robust, standardized order:

``` python
DEFAULT_BINDING_ORDER = ['pyqt', 'pyside']
```

### 🧪 Testing

- **Platform:** macOS 13.6 — 26.1 (25B78), Apple M2  
- **Python Version:** 3.11  
- **ROS 2 Distro:** kilted (Source)  
- **Verification:** `rqt` without import errors

<img width="1440" height="900" alt="Screenshot 2025-12-10 at 14 37 27" src="https://github.com/user-attachments/assets/d5127b39-da71-4a29-a3ba-5364d1dcbf0d" />


