### PR TITLE
Depend on python3-dev

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,7 @@
 
   <build_depend>qt6-base-dev</build_depend>
   <build_depend>python3-qt-bindings</build_depend>
+  <build_export_depend>python3-dev</build_export_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
#157 builds the cPython extension for sip buildings using python3_add_library. This requires python3-dev. This PR adds it to the package.xml to resolve this downstream build failure on the buildfarm:

```
23:31:22 CMake Error at /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
23:31:22   Could NOT find Python3 (missing: Python3_INCLUDE_DIRS Python3_LIBRARIES
23:31:22   Development Development.Module Development.Embed)
23:31:22 Call Stack (most recent call first):
23:31:22   /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
23:31:22   /usr/share/cmake-3.28/Modules/FindPython/Support.cmake:3862 (find_package_handle_standard_args)
23:31:22   /usr/share/cmake-3.28/Modules/FindPython3.cmake:545 (include)
23:31:22   src/qt_gui_cpp_sip/CMakeLists.txt:60 (find_package)
```

https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__qt_gui_cpp__ubuntu_noble_amd64__binary/116/console