### PR TITLE
Re-add exec depend on python3 qt bindings rosdep key

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -31,6 +31,8 @@
   <build_depend>python3-qt-bindings</build_depend>
   <build_export_depend>python3-dev</build_export_depend>
 
+  <exec_depend>python3-qt-bindings</exec_depend>
+
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>python3-qt-bindings</build_depend>
+  <build_export_depend>python3-qt-bindings</build_export_depend>
   <build_export_depend>python3-dev</build_export_depend>
 
   <exec_depend>python3-qt-bindings</exec_depend>


### PR DESCRIPTION
I think this is the source of the regression on rolling of qt_gui_cpp. When I replaced python3_qt5_bindings with `python3_qt_bindings`, I mistakenly removed the exec_depend

https://github.com/ros-visualization/python_qt_binding/pull/157/changes#diff-37a67ff78eb7260214b323353263b9af40a2fa98719a1e81937fae0159df87a3L34