### PR TITLE
Pick Qt version at build time, not install time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,15 @@ find_package(ament_cmake_python REQUIRED)
 # Copy python package into binary directory
 file(COPY src/${PROJECT_NAME} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-include(python_qt_binding-extras.cmake)
+# Avoid find_package(QT NAMES Qt6 Qt5 ...) due to CMake's default ascending path resolution
+find_package(Qt6 QUIET COMPONENTS Widgets Core)
+if(Qt6_FOUND)
+  set(QT_VERSION_MAJOR 6)
+else()
+  find_package(Qt5 REQUIRED COMPONENTS Widgets Core)
+  set(QT_VERSION_MAJOR 5)
+endif()
+set(python_qt_binding_QT_MAJOR_VERSION "${QT_VERSION_MAJOR}" CACHE STRING "The major version of Qt to use (5 or 6)")
 
 # Generate a version.py file inside the copied package directory
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/version.py
@@ -39,5 +47,5 @@ if(BUILD_TESTING)
 endif()
 
 ament_package(
-  CONFIG_EXTRAS "python_qt_binding-extras.cmake"
+  CONFIG_EXTRAS "python_qt_binding-extras.cmake.in"
 )

--- a/python_qt_binding-extras.cmake
+++ b/python_qt_binding-extras.cmake
@@ -1,9 +1,0 @@
-# Avoid find_package(QT NAMES Qt6 Qt5 ...) due to CMake's default ascending path resolution
-find_package(Qt6 QUIET COMPONENTS Widgets Core)
-if(Qt6_FOUND)
-  set(QT_VERSION_MAJOR 6)
-else()
-  find_package(Qt5 REQUIRED COMPONENTS Widgets Core)
-  set(QT_VERSION_MAJOR 5)
-endif()
-set(python_qt_binding_QT_MAJOR_VERSION "${QT_VERSION_MAJOR}" CACHE STRING "The major version of Qt to use (5 or 6)")

--- a/python_qt_binding-extras.cmake.in
+++ b/python_qt_binding-extras.cmake.in
@@ -1,0 +1,1 @@
+set(python_qt_binding_QT_MAJOR_VERSION "@python_qt_binding_QT_MAJOR_VERSION@" CACHE STRING "The major version of Qt to use (5 or 6)")


### PR DESCRIPTION
Still trying to fix [this rqt_image_view regression](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rqt_image_view__ubuntu_noble_amd64__binary/162/console). I noticed this code seems problematic. It was using logic to find Qt6 to decide which version to use at both build time and run time. Once python_qt_binding is built, the version of Qt to use at run time must match what was built. This PR accomplishes that by turning the extras file into a template that `ament_package` expands at build time.